### PR TITLE
added extra eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
-import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
@@ -19,9 +19,99 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          vars: 'all',
+          args: 'none',
+          ignoreRestSiblings: true,
+        },
+      ],
+
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: ['enum'],
+          format: ['UPPER_CASE'],
+          suffix: ['_ENUM'],
+        },
+        {
+          selector: ['enumMember'],
+          format: ['UPPER_CASE'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase', 'PascalCase'],
+        },
+        {
+          selector: 'property',
+
+          filter: {
+            regex: '^_oneall$',
+            match: true,
+          },
+
+          format: null,
+        },
+        {
+          selector: 'variable',
+          types: ['boolean'],
+          prefix: ['is', 'should', 'has', 'IS'],
+          format: null,
+        },
+        {
+          selector: 'variable',
+          format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+        },
+        {
+          selector: 'parameter',
+
+          filter: {
+            regex: '^_+$',
+            match: true,
+          },
+
+          format: null,
+        },
+        {
+          selector: 'parameter',
+          format: ['camelCase', 'PascalCase'],
+        },
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'objectLiteralProperty',
+
+          filter: {
+            regex: '^__typename|__html|aria-.+$',
+            match: true,
+          },
+
+          format: null,
+        },
+        {
+          selector: 'objectLiteralProperty',
+
+          filter: {
+            regex: '^[0-9]+$',
+            match: true,
+          },
+
+          format: null,
+        },
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+
+          custom: {
+            regex: '^I[A-Z][A-Za-z]*Props$|^I[A-Z][A-Za-z]*$',
+            match: true,
+          },
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,16 +46,6 @@ export default tseslint.config(
           format: ['camelCase', 'PascalCase'],
         },
         {
-          selector: 'property',
-
-          filter: {
-            regex: '^_oneall$',
-            match: true,
-          },
-
-          format: null,
-        },
-        {
           selector: 'variable',
           types: ['boolean'],
           prefix: ['is', 'should', 'has', 'IS'],


### PR DESCRIPTION
Rules added:

1. Enums must use UPPER_CASE and end with _ENUM.
2. Enum members must be UPPER_CASE.
3. Functions can use camelCase or PascalCase.
4. Boolean variables must start with is, should, has, or IS.
5. Variables can be camelCase, PascalCase, or UPPER_CASE.
6. Parameters can be camelCase, PascalCase, or underscores (_, __).
7. Interfaces must start with I and optionally end in Props.
8. Type-like elements (classes/types) must use PascalCase.
9. Numeric and special properties (e.g., aria-* or __html) are excluded from formatting rules.
